### PR TITLE
Support node >=4

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["eslatest-node6"],
+  "presets": [["env", { "targets": { "node": 4 } }]],
   "plugins": ["add-module-exports", "transform-flow-strip-types"]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - '4'
+  - '6'
+  - '7'
+
+notifications:
+  email: false

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.4.2",
   "description": "Compile LightScript to JavaScript.",
   "main": "index.js",
+  "engines": {
+    "node": ">=4"
+  },
   "scripts": {
     "test": "mocha test",
     "test:debug": "node --inspect --debug-brk mocha test",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha test",
-    "test:debug": "node --inspect --debug-brk node_modules/.bin/_mocha test",
+    "test:debug": "node --inspect --debug-brk mocha test",
     "build": "babel src --out-dir ."
   },
   "author": "Alex Rattray <rattray.alex@gmail.com> (http://alexrattray.com/)",
@@ -24,9 +24,9 @@
     "babel-eslint": "^7.0.0",
     "babel-helper-plugin-test-runner": "^6.18.0",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-preset-env": "^1.3.2",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
-    "babel-preset-eslatest-node6": "^1.0.1",
     "eslint": "^3.10.2",
     "eslint-config-babel": "^3.0.0",
     "eslint-plugin-babel": "^4.0.0",


### PR DESCRIPTION
Closes #10 

- Replace `babel-preset-eslatest-node6` with `babel-preset-env` and target down to node 4.x
- Add a travis ci config, should just have to activate the repo on [travis-ci.org](https://travis-ci.org/) and probably push something to kick off a build
- Travis will then test on versions 4, 6, & 7, and should be updated to test on LTS & current releases as they roll out
- Also a minor change to the `test:debug` script similar to the one we previously did for `test` for better cross-platform compat