### PR TITLE
Add npm prepublish hook.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "test": "mocha test",
     "test:debug": "node --inspect --debug-brk mocha test",
-    "build": "babel src --out-dir ."
+    "build": "babel src --out-dir .",
+    "prepublish": "npm run build"
   },
   "author": "Alex Rattray <rattray.alex@gmail.com> (http://alexrattray.com/)",
   "homepage": "http://lightscript.org/",


### PR DESCRIPTION
Let's prevent accidentally pushing a stale build and improve interoperabilty with tools like Lerna by adding a prepublish hook.