### PR TITLE
use cherry-pick style lodash imports

### DIFF
--- a/test/fixtures/stdlib/kitchen-sink/expected.js
+++ b/test/fixtures/stdlib/kitchen-sink/expected.js
@@ -1,4 +1,5 @@
-import { map, round } from 'lodash';
+import map from 'lodash/map';
+import round from 'lodash/round';
 
 function looseEq(a, b) {
   return a == b;

--- a/test/fixtures/stdlib/lodash-true/expected.js
+++ b/test/fixtures/stdlib/lodash-true/expected.js
@@ -1,2 +1,2 @@
-import { uniq } from "lodash";
+import uniq from "lodash/uniq";
 uniq();

--- a/test/fixtures/stdlib/overridden/expected.js
+++ b/test/fixtures/stdlib/overridden/expected.js
@@ -1,4 +1,4 @@
-import { map } from "lodash";
+import map from "lodash/map";
 
 function uniq() {
   return 1;

--- a/test/fixtures/stdlib/require-true/expected.js
+++ b/test/fixtures/stdlib/require-true/expected.js
@@ -6,10 +6,9 @@ function looseNotEq(a, b) {
   return a != b;
 }
 
-const {
-  map,
-  round
-} = require('lodash');
+const map = require('lodash/map');
+
+const round = require('lodash/round');
 
 looseEq(1, '1');
 looseNotEq(1, '1');


### PR DESCRIPTION
As discussed on gitter, currently we generate:

```js
import { map, round } from 'lodash';
// or the require equivalent:
const { map, round } = require('lodash')
```

... which, aside from reliable ES module tree-shaking, imports the entirety of lodash. We'll instead use:

```js
import map from 'lodash/map';
import round from 'lodash/round';
// or the require equivalent:
const map = require('lodash/map')
const round = require('lodash/round')
```

This is essentially what `babel-plugin-lodash` does to optimize file sizes.

